### PR TITLE
sld-1 Add support to alpha colour

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>au.gov.aims</groupId>
 	<artifactId>sld</artifactId>
-	<version>0.1.9</version>
+	<version>0.1.10</version>
 	<packaging>jar</packaging>
 
 	<properties>

--- a/src/main/java/au/gov/aims/sld/SldUtils.java
+++ b/src/main/java/au/gov/aims/sld/SldUtils.java
@@ -49,19 +49,45 @@ public class SldUtils {
 		return true;
 	}
 
-	public static Color parseHexColor(String hexColor, Double opacity) {
-		if (hexColor == null || hexColor.length() != 7 || !hexColor.startsWith("#")) {
+	public static Color parseHexColour(String hexColour) {
+		return parseHexColour(hexColour, 1.0);
+	}
+
+	public static Color parseHexColour(String hexColour, Double opacity) {
+		if (hexColour == null || !hexColour.startsWith("#")) {
 			return null;
 		}
 
-		int intOpacity = opacity == null ? 255 :
-				(int)Math.round(opacity * 255);
+		int hexLength = hexColour.length();
+		if (hexLength != 7 && hexLength != 9) {
+			return null;
+		}
+
+		int intOpacity = 255;
+		if (hexLength == 9) {
+			intOpacity = Integer.valueOf(hexColour.substring(7, 9), 16);
+
+		} else if (hexLength == 7) {
+			intOpacity = opacity == null ? 255 :
+					(int)Math.round(opacity * 255);
+		}
 
 		return new Color(
-			Integer.valueOf(hexColor.substring(1, 3), 16),
-			Integer.valueOf(hexColor.substring(3, 5), 16),
-			Integer.valueOf(hexColor.substring(5, 7), 16),
+			Integer.valueOf(hexColour.substring(1, 3), 16),
+			Integer.valueOf(hexColour.substring(3, 5), 16),
+			Integer.valueOf(hexColour.substring(5, 7), 16),
 			intOpacity
 		);
+	}
+
+	/**
+	 * @param hexColour
+	 * @param opacity
+	 * @return
+	 * @deprecated Use parseHexColour
+	 */
+	@Deprecated
+	public static Color parseHexColor(String hexColour, Double opacity) {
+		return parseHexColour(hexColour, opacity);
 	}
 }

--- a/src/main/java/au/gov/aims/sld/symbolizer/attributes/Fill.java
+++ b/src/main/java/au/gov/aims/sld/symbolizer/attributes/Fill.java
@@ -62,7 +62,7 @@ public class Fill extends Attribute {
 
 	public Paint getFillPaint() {
 		return this.fillColour == null ? null :
-				SldUtils.parseHexColor(this.fillColour, this.fillOpacity);
+				SldUtils.parseHexColour(this.fillColour, this.fillOpacity);
 	}
 
 	@Override

--- a/src/main/java/au/gov/aims/sld/symbolizer/attributes/Stroke.java
+++ b/src/main/java/au/gov/aims/sld/symbolizer/attributes/Stroke.java
@@ -99,7 +99,7 @@ public class Stroke extends Attribute {
 
 	public Paint getStrokePaint() {
 		return this.strokeColour == null ? null :
-				SldUtils.parseHexColor(this.strokeColour, this.strokeOpacity);
+				SldUtils.parseHexColour(this.strokeColour, this.strokeOpacity);
 	}
 
 	public java.awt.Stroke getStroke() {

--- a/src/test/java/au/gov/aims/sld/SldUtilsTest.java
+++ b/src/test/java/au/gov/aims/sld/SldUtilsTest.java
@@ -1,0 +1,59 @@
+/*
+ *  Copyright (C) 2020 Australian Institute of Marine Science
+ *
+ *  Contact: Gael Lafond <g.lafond@aims.org.au>
+ *
+ *  This program is free software: you can redistribute it and/or modify
+ *  it under the terms of the GNU General Public License as published by
+ *  the Free Software Foundation, either version 3 of the License, or
+ *  (at your option) any later version.
+ *
+ *  This program is distributed in the hope that it will be useful,
+ *  but WITHOUT ANY WARRANTY; without even the implied warranty of
+ *  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ *  GNU General Public License for more details.
+ *
+ *  You should have received a copy of the GNU General Public License
+ *  along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package au.gov.aims.sld;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.awt.Color;
+
+public class SldUtilsTest {
+
+    @Test(expected = NumberFormatException.class)
+    public void testParseBadHexColour() {
+        String hexColour = "#POTATO";
+        Color parsedColour = SldUtils.parseHexColour(hexColour);
+
+        Assert.assertNull(String.format("The string %s returned a colour?", hexColour), parsedColour);
+    }
+
+    @Test
+    public void testParseHexColour() {
+        String hexColour = "#FF9900";
+        Color parsedColour = SldUtils.parseHexColour(hexColour);
+
+        Assert.assertNotNull(String.format("The Hex colour string %s could not be parsed", hexColour), parsedColour);
+        Assert.assertEquals("Wrong red", 0xFF, parsedColour.getRed());
+        Assert.assertEquals("Wrong green", 0x99, parsedColour.getGreen());
+        Assert.assertEquals("Wrong blue", 0, parsedColour.getBlue());
+        Assert.assertEquals("Wrong alpha", 255, parsedColour.getAlpha());
+    }
+
+    @Test
+    public void testParseHexColourWithAlpha() {
+        String hexColour = "#124578AB";
+        Color parsedColour = SldUtils.parseHexColour(hexColour);
+
+        Assert.assertNotNull(String.format("The Hex colour string %s could not be parsed", hexColour), parsedColour);
+        Assert.assertEquals("Wrong red", 0x12, parsedColour.getRed());
+        Assert.assertEquals("Wrong green", 0x45, parsedColour.getGreen());
+        Assert.assertEquals("Wrong blue", 0x78, parsedColour.getBlue());
+        Assert.assertEquals("Wrong alpha", 0xAB, parsedColour.getAlpha());
+    }
+}

--- a/src/test/java/au/gov/aims/sld/TestUtils.java
+++ b/src/test/java/au/gov/aims/sld/TestUtils.java
@@ -20,6 +20,9 @@ package au.gov.aims.sld;
 
 import java.io.InputStream;
 
+/**
+ * List of methods used in tests (to avoid code duplication)
+ */
 public class TestUtils {
 
 	protected static StyleSheet getStyleSheet(SldParser parser, String sldPath) throws Exception {


### PR DESCRIPTION
Issue #1 ver 0.1.10
- Deprecated parseHexColor in favor of parseHexColour
- Added parseHexColour(String hexColour) which used opacity of 1.0 (255) by default
- Added support for RGBA colour ("#RRGGBBAA")
- Added JUnit test for SldUtils