### PR TITLE
sld-3 BinaryLogicalFilter must be unbounded

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
 	<groupId>au.gov.aims</groupId>
 	<artifactId>sld</artifactId>
-	<version>0.1.10</version>
+	<version>0.2.0</version>
 	<packaging>jar</packaging>
 
 	<properties>

--- a/src/main/java/au/gov/aims/sld/filter/logical/And.java
+++ b/src/main/java/au/gov/aims/sld/filter/logical/And.java
@@ -18,11 +18,16 @@
  */
 package au.gov.aims.sld.filter.logical;
 
+import au.gov.aims.sld.filter.Filter;
 import au.gov.aims.sld.geom.GeoShape;
 
 public class And extends BinaryLogicalFilter {
 	@Override
 	public boolean filter(GeoShape geoShape) {
-		return this.getLeftFilter().filter(geoShape) && this.getRightFilter().filter(geoShape);
+		boolean result = this.getLeftFilter().filter(geoShape);
+		for (Filter rightFilter : this.getRightFilters()) {
+			result = result && rightFilter.filter(geoShape);
+		}
+		return result;
 	}
 }

--- a/src/main/java/au/gov/aims/sld/filter/logical/BinaryLogicalFilter.java
+++ b/src/main/java/au/gov/aims/sld/filter/logical/BinaryLogicalFilter.java
@@ -24,22 +24,24 @@ import au.gov.aims.sld.filter.FilterFactory;
 import org.w3c.dom.Node;
 
 import javax.xml.xpath.XPath;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+// http://schemas.opengis.net/filter/1.1.0/filter.xsd
 public abstract class BinaryLogicalFilter extends LogicalFilter {
 	private static final Logger LOGGER = Logger.getLogger(BinaryLogicalFilter.class.getSimpleName());
 
 	private Filter leftFilter;
-	private Filter rightFilter;
+	private List<Filter> rightFilters;
 
 	public Filter getLeftFilter() {
 		return this.leftFilter;
 	}
 
-	public Filter getRightFilter() {
-		return this.rightFilter;
+	public List<Filter> getRightFilters() {
+		return this.rightFilters;
 	}
 
 	@Override
@@ -50,8 +52,8 @@ public abstract class BinaryLogicalFilter extends LogicalFilter {
 			return;
 		}
 
-		if (elements.size() != 2) {
-			LOGGER.log(Level.WARNING, "Binary filter contains " + elements.size() + " elements. Expected 2.");
+		if (elements.size() < 2) {
+			LOGGER.log(Level.WARNING, String.format("Binary filter contains %d elements. Expected minimum 2.", elements.size()));
 			return;
 		}
 
@@ -61,21 +63,25 @@ public abstract class BinaryLogicalFilter extends LogicalFilter {
 			return;
 		}
 
-		Filter rightFilter = FilterFactory.fromXML(elements.get(1), xPath);
-		if (rightFilter == null) {
-			LOGGER.log(Level.WARNING, "Binary filter contains invalid right element.");
-			return;
+		List<Filter> rightFilters = new ArrayList<Filter>();
+		for (int i=1; i<elements.size(); i++) {
+			Filter rightFilter = FilterFactory.fromXML(elements.get(i), xPath);
+			if (rightFilter == null) {
+				LOGGER.log(Level.WARNING, String.format("Binary filter contains invalid right element, index %d.", i));
+				return;
+			}
+			rightFilters.add(rightFilter);
 		}
 
 		this.leftFilter = leftFilter;
-		this.rightFilter = rightFilter;
+		this.rightFilters = rightFilters;
 	}
 
 	@Override
 	public String toString() {
 		return "BinaryLogicalFilter{" +
-				"leftFilter=" + leftFilter +
-				", rightFilter=" + rightFilter +
+				"leftFilter=" + this.leftFilter +
+				", rightFilters=" + this.rightFilters +
 				'}';
 	}
 }

--- a/src/main/java/au/gov/aims/sld/filter/logical/Or.java
+++ b/src/main/java/au/gov/aims/sld/filter/logical/Or.java
@@ -18,11 +18,16 @@
  */
 package au.gov.aims.sld.filter.logical;
 
+import au.gov.aims.sld.filter.Filter;
 import au.gov.aims.sld.geom.GeoShape;
 
 public class Or extends BinaryLogicalFilter {
 	@Override
 	public boolean filter(GeoShape geoShape) {
-		return this.getLeftFilter().filter(geoShape) || this.getRightFilter().filter(geoShape);
+		boolean result = this.getLeftFilter().filter(geoShape);
+		for (Filter rightFilter : this.getRightFilters()) {
+			result = result || rightFilter.filter(geoShape);
+		}
+		return result;
 	}
 }


### PR DESCRIPTION
Issue #3, ver 0.2.0
- BinaryLogicalFilter: changed "Filter rightFilter" to "List<Filter> rightFilters", and changed API accordingly.
- Fixed Or and And binary operators to follow the new BinaryLogicalFilter API.